### PR TITLE
REST Messaging System

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,12 +61,19 @@ app.use('/v1', apiRouter)
  * */
 app.use(rest.messenger)
 
+//catch 404 because of an invalid site path outside of /v1/, and error out
+app.use(function(req, res, next) {
+    let msg = res.statusMessage ? res.statusMessage : "This page does not exist"
+    res.status(404).send(msg)  
+    res.end()
+})
+
 /**
  * Not even the messenger could figure out what to do.  500 out hard. 
  */
 app.use((err, req, res, next) => {
   console.error(err.stack)
-  res.status(500).send('Something broke!')
+  res.status(500).send('Something went wrong under the hood.')
 })
 
 module.exports = app

--- a/app.js
+++ b/app.js
@@ -61,19 +61,11 @@ app.use('/v1', apiRouter)
  * */
 app.use(rest.messenger)
 
-//catch 404 because of an invalid site path outside of /v1/, and error out
+//catch 404 because of an invalid site path
 app.use(function(req, res, next) {
     let msg = res.statusMessage ? res.statusMessage : "This page does not exist"
     res.status(404).send(msg)  
     res.end()
-})
-
-/**
- * Not even the messenger could figure out what to do.  500 out hard. 
- */
-app.use((err, req, res, next) => {
-  console.error(err.stack)
-  res.status(500).send('Something went wrong under the hood.')
 })
 
 module.exports = app

--- a/app.js
+++ b/app.js
@@ -48,13 +48,9 @@ app.all('*', (req, res, next) => {
       next() //pass on to the next app.use
   }
 })
+
 app.use('/', indexRouter)
 app.use('/v1', apiRouter)
-
-// catch 404 because of an invalid site path, and error out
-app.use(function(req, res, next) {
-  next(createError(404))
-})
 
 /**
  * Handle API errors and warnings RESTfully.  All routes that don't end in res.send() will end up here.
@@ -72,4 +68,5 @@ app.use((err, req, res, next) => {
   console.error(err.stack)
   res.status(500).send('Something broke!')
 })
+
 module.exports = app

--- a/app.js
+++ b/app.js
@@ -10,11 +10,13 @@ var storedEnv = dotenv.config()
 dotenvExpand.expand(storedEnv)
 var logger = require('morgan')
 const cors = require('cors')
+const rest_messenger = require("./rest.js")
 
 var indexRouter = require('./routes/index.js')
 var apiRouter = require('./routes/api-routes.js')
 
 //var utils = require('utils.js')
+const rest = require('./rest.js')
 var app = express()
 
 // view engine setup
@@ -50,21 +52,25 @@ app.all('*', (req, res, next) => {
 app.use('/', indexRouter)
 app.use('/v1', apiRouter)
 
-
-// catch 404 and forward to error handler
+// catch 404 because of an invalid site path, and error out
 app.use(function(req, res, next) {
   next(createError(404))
 })
 
-// error handler
-app.use(function(err, req, res, next) {
-  // set locals, only providing error in development
-  res.locals.message = err.message
-  res.locals.error = req.app.get('env') === 'development' ? err : {}
+/**
+ * Handle API errors and warnings RESTfully.  All routes that don't end in res.send() will end up here.
+ * Important to note that res.json() will fail to here
+ * Important to note api-routes.js handles all the 405s without failing to here - they res.send()
+ * Important to note that failures in the controller from the mongo client will fail to here
+ * 
+ * */
+app.use(rest.messenger)
 
-  // render the error page
-  res.status(err.status || 500)
-  res.render('error')
+/**
+ * Not even the messenger could figure out what to do.  500 out hard. 
+ */
+app.use((err, req, res, next) => {
+  console.error(err.stack)
+  res.status(500).send('Something broke!')
 })
-
 module.exports = app

--- a/db-controller.js
+++ b/db-controller.js
@@ -2,9 +2,10 @@
 
 const { MongoClient } = require('mongodb')
 var ObjectID = require('mongodb').ObjectID
-const client = new MongoClient(process.env.MONGO_CONNECTION_STRING);
-client.connect();
-console.log("Controller is made a mongo connection...")
+const client = new MongoClient(process.env.MONGO_CONNECTION_STRING)
+const rest = require('./rest.js')
+client.connect()
+console.log("Controller has made a mongo connection...")
 
 // Handle index actions
 exports.index = function (req, res) {
@@ -20,39 +21,31 @@ exports.index = function (req, res) {
  * */
 exports.create = async function (req, res) {
     res.set("Content-Type", "application/json; charset=utf-8")
-    try{
-        const id = new ObjectID().toHexString()
-        let obj = req.body //Is that JSON?  If not, then 400
-        obj["_id"] = id
-        obj["@id"] = process.env.RERUM_ID_PREFIX+id
-        console.log("Creating an object (no history or __rerum yet)")
-        console.log(obj)
-        let result = await client.db(process.env.MONGODBNAME).collection(process.env.MONGODBCOLLECTION).insertOne(obj)
-        res.location(obj["@id"])
-        res.status(201)
-        res.json(obj)
-    }
-    catch(err){
-        console.error("Could not perform create, see error below")
-        console.log(err)
-        //rest.message(res, err)
-        res.json({"err":err})
-    }
+    const id = new ObjectID().toHexString()
+    let obj = req.body
+    obj["_id"] = id
+    obj["@id"] = process.env.RERUM_ID_PREFIX+id
+    console.log("Creating an object (no history or __rerum yet)")
+    console.log(obj)
+    let result = await client.db(process.env.MONGODBNAME).collection(process.env.MONGODBCOLLECTION).insertOne(obj)
+    res.location(obj["@id"])
+    res.status(201)
+    res.json(obj)
 }
 
 /**
- * Create a new Linked Open Data object in RERUM v1.
+ * Mark an object as deleted in the database.
+ * Support /api/delete/{id} as well as DELETE with JSON body containing a detectable '@id'
  * Respond RESTfully
  * */
 exports.delete = async function (req, res) {
-    try{
-        res.status(501).send("You will get a 204 upon success.  This is not supported yet.  Nothing happened.")
+    let id = req.params["_id"]?req.params["_id"]:""
+    if(id === undefined || id === ""){
+        res.status(400).send("You must provide an id as part of the /api/delete/{id} URL or in the request body with {'@id':''}.  "  
+        +"Without an ID, there is nothing to look for.")
+        return false
     }
-    catch(err){
-        console.error("Could not perform delete, see error below")
-        console.log(err)
-        res.json({"err":err})
-    }
+    res.status(501).send("You will get a 204 upon success.  This is not supported yet.  Nothing happened.")
 }
 
 /**
@@ -61,14 +54,7 @@ exports.delete = async function (req, res) {
  * Respond RESTfully
  * */
 exports.putUpdate = async function (req, res) {
-    try{
-        res.status(501).send("You will get a 204 upon success.  This is not supported yet.  Nothing happened.")
-    }
-    catch(err){
-        console.error("Could not PUT update, see error below")
-        console.log(err)
-        res.json({"err":err})
-    }
+    res.status(501).send("You will get a 204 upon success.  This is not supported yet.  Nothing happened.")
 }
 
 /**
@@ -78,14 +64,7 @@ exports.putUpdate = async function (req, res) {
  * Respond RESTfully
  * */
 exports.patchUpdate = async function (req, res) {
-    try{
-        res.status(501).send("You will get a 204 upon success.  This is not supported yet.  Nothing happened.")
-    }
-    catch(err){
-        console.error("Could not perform PATCH update, see error below")
-        console.log(err)
-        res.json({"err":err})
-    }
+    res.status(501).send("You will get a 204 upon success.  This is not supported yet.  Nothing happened.")
 }
 
 /**
@@ -96,14 +75,7 @@ exports.patchUpdate = async function (req, res) {
  * Respond RESTfully
  * */
 exports.patchSet = async function (req, res) {
-    try{
-        res.status(501).send("You will get a 204 upon success.  This is not supported yet.  Nothing happened.")
-    }
-    catch(err){
-        console.error("Could not perform PATCH set, see error below")
-        console.log(err)
-        res.json({"err":err})
-    }
+    res.status(501).send("You will get a 204 upon success.  This is not supported yet.  Nothing happened.")   
 }
 
 /**
@@ -114,14 +86,7 @@ exports.patchSet = async function (req, res) {
  * Respond RESTfully
  * */
 exports.patchUnset = async function (req, res) {
-    try{
-        res.status(501).send("You will get a 204 upon success.  This is not supported yet.  Nothing happened.")
-    }
-    catch(err){
-        console.error("Could not perform PATCH Unset, see error below")
-        console.log(err)
-        res.json({"err":err})
-    }
+    res.status(501).send("You will get a 204 upon success.  This is not supported yet.  Nothing happened.")
 }
 
 /**
@@ -131,30 +96,23 @@ exports.patchUnset = async function (req, res) {
  * */
 exports.overwrite = async function (req, res) {
     res.set("Content-Type", "application/json; charset=utf-8")
-    try{
-        let obj = req.body
-        if(obj.hasOwnProperty("@id")){
-            console.log("Overwriting an object (no history or __rerum yet)")
-            const query = {"@id":obj["@id"]}
-            let result = await client.db(process.env.MONGODBNAME).collection(process.env.MONGODBCOLLECTION).replaceOne(query, obj)
-            if(result.modifiedCount > 0){
-                res.set("Location", obj["@id"])
-                res.json(obj)
-            }
-            else{
-                res.sendStatus(304)
-            }
-        }    
+    let obj = req.body
+    if(obj.hasOwnProperty("@id")){
+        console.log("Overwriting an object (no history or __rerum yet)")
+        const query = {"@id":obj["@id"]}
+        let result = await client.db(process.env.MONGODBNAME).collection(process.env.MONGODBCOLLECTION).replaceOne(query, obj)
+        if(result.modifiedCount > 0){
+            res.set("Location", obj["@id"])
+            res.json(obj)
+        }
         else{
-            //Can I set the 400 status here?
-            res.json({"err" : "Object in request body must have the property '@id'."})
-        } 
-    }
-    catch(err){
-        console.error("Could not perform overwrite, see error below")
-        console.log(err)
-        res.json({"err":err})
-    }
+            res.sendStatus(304)
+        }
+    }    
+    else{
+        //Can I set the 400 status here?
+        res.json({"err" : "Object in request body must have the property '@id'."})
+    } 
 }
 
 /**
@@ -166,19 +124,12 @@ exports.overwrite = async function (req, res) {
  * */
 exports.query = async function (req, res) {
     res.set("Content-Type", "application/json; charset=utf-8")
-    try{
-        let props = req.body
-        console.log("Looking matches against props...")
-        console.log(props)
-        let matches = await client.db(process.env.MONGODBNAME).collection(process.env.MONGODBCOLLECTION).find(props).toArray()
-        console.log(matches)
-        res.json(matches)
-    }
-    catch(err){
-        console.error("Could not perform query, see error below")
-        console.log(err)
-        res.json([])
-    }
+    let props = req.body
+    console.log("Looking matches against props...")
+    console.log(props)
+    let matches = await client.db(process.env.MONGODBNAME).collection(process.env.MONGODBCOLLECTION).find(props).toArray()
+    console.log(matches)
+    res.json(matches)
 }
 
 /**
@@ -188,21 +139,19 @@ exports.query = async function (req, res) {
  * Respond RESTfully
  * */
 exports.id = async function (req, res) {
-    console.log("Controller.id Here...")
     res.set("Content-Type", "application/json; charset=utf-8")
-    try{
-        let id = req.params["_id"]
-        let match = await client.db(process.env.MONGODBNAME).collection(process.env.MONGODBCOLLECTION).findOne({"_id" : id})
-        if(match){
-            res.json(match)    
-        }
-        else{
-            res.sendStatus(404)
-        }  
+    let id = req.params["_id"]
+    if(id === undefined || id === ""){
+        res.status(400).send("You must provide an id as part of the /v1/id/{id} URL.  Without an ID, there is nothing to look for.")
+        return false
     }
-    catch(err){
-        res.status(500).send("Could not perform lookup by id.")
+    let match = await client.db(process.env.MONGODBNAME).collection(process.env.MONGODBCOLLECTION).findOne({"_id" : id})
+    if(match){
+        res.json(match)    
     }
+    else{
+        res.sendStatus(404)
+    }  
 }
 
 //Connect to a mongodb via mongodb node driver.
@@ -229,26 +178,21 @@ async function mongoConnection(){
  * */
 exports.idHeadRequest = async function(req, res){
     res.set("Content-Type", "application/json; charset=utf-8")
-    try{
-        let id = req.params["_id"]
-        if(id){
-            let match = await client.db(process.env.MONGODBNAME).collection(process.env.MONGODBCOLLECTION).findOne({"_id" : id})
-            if(match){
-                const size = Buffer.byteLength(JSON.stringify(match))
-                res.set("Content-Length", size)
-                res.sendStatus(200)    
-            }
-            else{
-                res.sendStatus(404)
-            }      
+    let id = req.params["_id"]
+    if(id){
+        let match = await client.db(process.env.MONGODBNAME).collection(process.env.MONGODBCOLLECTION).findOne({"_id" : id})
+        if(match){
+            const size = Buffer.byteLength(JSON.stringify(match))
+            res.set("Content-Length", size)
+            res.sendStatus(200)    
         }
         else{
-            //This is a bad request, an ID must be provided in the URL
-            res.status(400).send("You must provide an id as part of the /v1/id/{id} URL.  Without an ID, there is nothing to look for.")
-        }
+            res.sendStatus(404)
+        }      
     }
-    catch(err){
-        res.status(500).send("Could not process HEAD request.  Request was like /v1/id/abcde")
+    else{
+        //This is a bad request, an ID must be provided in the URL
+        res.status(400).send("You must provide an id as part of the /v1/id/{id} URL.  Without an ID, there is nothing to look for.")
     }
 }
 
@@ -258,20 +202,15 @@ exports.idHeadRequest = async function(req, res){
  * */
 exports.queryHeadRequest = async function(req, res){
     res.set("Content-Type", "application/json; charset=utf-8")
-    try{
-        let props = req.body
-        let matches = await client.db(process.env.MONGODBNAME).collection(process.env.MONGODBCOLLECTION).find(props).toArray()
-        if(matches.length){
-            const size = Buffer.byteLength(JSON.stringify(match))
-            res.set("Content-Length", size)
-            res.sendStatus(200)    
-        }
-        else{
-            res.set("Content-Length", 0)
-            res.sendStatus(204)    
-        }
+    let props = req.body
+    let matches = await client.db(process.env.MONGODBNAME).collection(process.env.MONGODBCOLLECTION).find(props).toArray()
+    if(matches.length){
+        const size = Buffer.byteLength(JSON.stringify(match))
+        res.set("Content-Length", size)
+        res.sendStatus(200)    
     }
-    catch(err){
-        res.status(500).send("Could not process HEAD request.  Request was like /v1/api/query")
+    else{
+        res.set("Content-Length", 0)
+        res.sendStatus(204)    
     }
 }

--- a/db-controller.js
+++ b/db-controller.js
@@ -24,7 +24,6 @@ exports.create = async function (req, res) {
         const id = new ObjectID().toHexString()
         let obj = req.body //Is that JSON?  If not, then 400
         obj["_id"] = id
-        //REMEMBER in the java this is a Constant.  Maybe this is the time to make it process.env
         obj["@id"] = process.env.RERUM_ID_PREFIX+id
         console.log("Creating an object (no history or __rerum yet)")
         console.log(obj)
@@ -36,6 +35,7 @@ exports.create = async function (req, res) {
     catch(err){
         console.error("Could not perform create, see error below")
         console.log(err)
+        //rest.message(res, err)
         res.json({"err":err})
     }
 }
@@ -115,7 +115,7 @@ exports.patchSet = async function (req, res) {
  * */
 exports.patchUnset = async function (req, res) {
     try{
-        res.status(501).send("This is not supported yet.  Nothing happened.")
+        res.status(501).send("You will get a 204 upon success.  This is not supported yet.  Nothing happened.")
     }
     catch(err){
         console.error("Could not perform PATCH Unset, see error below")
@@ -231,15 +231,21 @@ exports.idHeadRequest = async function(req, res){
     res.set("Content-Type", "application/json; charset=utf-8")
     try{
         let id = req.params["_id"]
-        let match = await client.db(process.env.MONGODBNAME).collection(process.env.MONGODBCOLLECTION).findOne({"_id" : id})
-        if(match){
-            const size = Buffer.byteLength(JSON.stringify(match))
-            res.set("Content-Length", size)
-            res.sendStatus(200)    
+        if(id){
+            let match = await client.db(process.env.MONGODBNAME).collection(process.env.MONGODBCOLLECTION).findOne({"_id" : id})
+            if(match){
+                const size = Buffer.byteLength(JSON.stringify(match))
+                res.set("Content-Length", size)
+                res.sendStatus(200)    
+            }
+            else{
+                res.sendStatus(404)
+            }      
         }
         else{
-            res.sendStatus(404)
-        }  
+            //This is a bad request, an ID must be provided in the URL
+            res.status(400).send("You must provide an id as part of the /v1/id/{id} URL.  Without an ID, there is nothing to look for.")
+        }
     }
     catch(err){
         res.status(500).send("Could not process HEAD request.  Request was like /v1/id/abcde")

--- a/db-controller.js
+++ b/db-controller.js
@@ -47,13 +47,18 @@ exports.create = async function (req, res, next) {
  * Support /v1/delete/{id}.  Note this is not v1/api/delete, that is not possible (XHR does not support DELETE with body)
  * Note /v1/delete/{blank} does not route here.  It routes to the generic 404.
  * Respond RESTfully
+ * 
+ * The user may be trying to call /delete and pass in the obj in the body.  XHR does not support bodies in delete.
+ * If there is no id parameter, this is a 400
+ * 
+ * If there is an id parameter, we ignore body, and continue with that id
+ * 
  * */
 exports.delete = async function (req, res, next) {
     let id = req.params["_id"]?req.params["_id"]:""
-    res.status(501).send("You will get a 204 upon success.  This is not supported yet.  Nothing happened.")
-    //res.status(501)
-    //res.statusMessage = "You will get a 204 upon success.  This is not supported yet.  Nothing happened."
-    //next()
+    res.status(501)
+    res.statusMessage = "You will get a 204 upon success.  This is not supported yet.  Nothing happened."
+    next()
 }
 
 /**
@@ -62,10 +67,9 @@ exports.delete = async function (req, res, next) {
  * Respond RESTfully
  * */
 exports.putUpdate = async function (req, res, next) {
-    res.status(501).send("You will get a 200 upon success.  This is not supported yet.  Nothing happened.")
-    //res.statusMessage = "You will get a 200 upon success.  This is not supported yet.  Nothing happened."
-    //res.status(501)
-    //next()
+    res.statusMessage = "You will get a 200 upon success.  This is not supported yet.  Nothing happened."
+    res.status(501)
+    next()
 }
 
 /**
@@ -76,10 +80,9 @@ exports.putUpdate = async function (req, res, next) {
  * Respond RESTfully
  * */
 exports.patchUpdate = async function (req, res, next) {
-    res.status(501).send("You will get a 200 upon success.  This is not supported yet.  Nothing happened.")
-    //res.statusMessage = "You will get a 200 upon success.  This is not supported yet.  Nothing happened."
-    //res.status(501)
-    //next()
+    res.statusMessage = "You will get a 200 upon success.  This is not supported yet.  Nothing happened."
+    res.status(501)
+    next()
 }
 
 /**
@@ -90,10 +93,9 @@ exports.patchUpdate = async function (req, res, next) {
  * Respond RESTfully
  * */
 exports.patchSet = async function (req, res, next) {
-    res.status(501).send("You will get a 200 upon success.  This is not supported yet.  Nothing happened.")
-    //res.statusMessage = "You will get a 200 upon success.  This is not supported yet.  Nothing happened."
-    //res.status(501)
-    //next()
+    res.statusMessage = "You will get a 200 upon success.  This is not supported yet.  Nothing happened."
+    res.status(501)
+    next()
 }
 
 /**
@@ -104,10 +106,9 @@ exports.patchSet = async function (req, res, next) {
  * Respond RESTfully
  * */
 exports.patchUnset = async function (req, res, next) {
-    res.status(501).send("You will get a 200 upon success.  This is not supported yet.  Nothing happened.")
-    //res.statusMessage = "You will get a 200 upon success.  This is not supported yet.  Nothing happened."
-    //res.status(501)
-    //next()
+    res.statusMessage = "You will get a 200 upon success.  This is not supported yet.  Nothing happened."
+    res.status(501)
+    next()
 }
 
 /**
@@ -132,10 +133,9 @@ exports.overwrite = async function (req, res, next) {
     }    
     else{
         //This is a custom one, the http module will not detect this as a 400 on its own
-        res.status(400).send("Object in request body must have the property '@id'.")
-        //res.statusMessage = "Object in request body must have the property '@id'."
-        //res.status(400)
-        //next()
+        res.statusMessage = "Object in request body must have the property '@id'."
+        res.status(400)
+        next()
     } 
 }
 
@@ -171,10 +171,9 @@ exports.id = async function (req, res, next) {
         res.json(match)    
     }
     else{
-        console.log("THERE was no object!!")
-        res.status(404).send("There is no object in the database with this id.  Check the URL.")
-        //res.statusMessage = "There is no object in the database with this id.  Check the URL."
-        //next()
+        res.statusMessage = "There is no object in the database with this id.  Check the URL."
+        res.status(404)
+        next()
     }  
 }
 
@@ -193,10 +192,9 @@ exports.idHeadRequest = async function(req, res, next){
         res.sendStatus(200)    
     }
     else{
-        res.status(404).send("There is no object in the database with this id.  Check the URL.")
-        //res.statusMessage = "There is no object in the database with this id.  Check the URL."
-        //res.status(404)
-        //next()
+        res.statusMessage = "There is no object in the database with this id.  Check the URL."
+        res.status(404)
+        next()
     }      
 }
 

--- a/rest.js
+++ b/rest.js
@@ -47,3 +47,60 @@ exports.checkPatchOverrideSupport = function(req, res){
         res.status(405).send('Improper request method for updating, please use PATCH to alter existing keys on this object.')
     }
 }
+
+/**
+ * Throughout the routes are certain warning, error, and hard fail scenarios.
+ * REST is all about communication.  The response code and the textual body are particular.
+ * RERUM is all about being clear.  It will build custom responses sometimes for certain scenarios, will remaining RESTful.
+ */
+exports.messenger = function(res, err){
+    const responseCode = res.statusCode
+    const responseMessage = res.statusMessage
+    let customResponseBody = {}
+    customResponseBody.http_response_code = responseCode
+    switch (responseCode){
+        case 400:
+            //"Bad Request", most likely because the body and Content-Type are not aligned.  Could be bad JSON.
+            customResponseBody.message = 
+            "The body of your request was invalid. Please make sure it is a valid content-type and that the body matches that type.  "
+            +"If the body is JSON, make sure it is valid JSON."
+        break
+        case 401:
+            //The requesting agent is known from the request.  That agent does not match __rerum.generatedBy.  Unauthorized.
+            customResponseBody.message = 
+            "This application is not the generator for the object you are trying to alter.  Fork the object via an update to make changes."
+        break
+        case 403:
+            //Forbidden to use this.  There may not be an Authorization header, or that header is invalid, or the Bearer is not known to RERUM.
+            if(res.getHeader("Authorization")){
+                customResponseBody.message = 
+                "RERUM could not authorize you to perform this action.  The 'Bearer' is not of RERUM.  "
+                +"Make sure you have registered at "+process.env.RERUM_PREFIX
+            }
+            else{
+                customResponseBody.message = 
+                "Improper or missing Authorization header provided on request.  Required header must be 'Authorization: Bearer {token}'.  "
+                +"Make sure you have registered at "+process.env.RERUM_PREFIX
+            }  
+        break
+        case 404:
+            //I think these are so self explanatory that we may not do anything custom with it.
+        break
+        case 405:
+            //I think these are all handled in api-routes.js already.  Not sure we will pass into here for the 405 messages.
+        break
+        case 500:
+            //Really bad, probably not specifically caught.  
+            customResponseBody.message = "RERUM experienced a server issue while performing this action.  "
+            +"It may not have completed at all, and most likely did not complete successfully."
+        case 503:
+            //RERUM is down
+            customResponseBody.message = "RERUM v1 is down for updates or maintenance at this time.  "  
+            +"We aplologize for the inconvenience.  Try again later."
+        break
+
+
+    }
+}
+
+

--- a/rest.js
+++ b/rest.js
@@ -41,8 +41,6 @@ exports.messenger = function(err, req, res, next){
         console.log("Middleware cannot control this error.  Headers are sent.")
         return next(err)
     }
-    console.log("In messenger with "+res.statusCode+" and "+res.statusMessage)
-    console.log("In messenger with "+err.statusCode+" and "+err.statusMessage)
     let customResponseBody = {}
     let statusCode = err.statusCode ? err.statusCode : res.statusCode ? res.statusCode : 500
     customResponseBody.http_response_code = statusCode

--- a/rest.js
+++ b/rest.js
@@ -1,15 +1,12 @@
 #!/usr/bin/env node
+
 /**
- * Support OPTIONS request, which are essentially CORS enabled heartbeats.  
- * */
-exports.optionsRequest = function (req, res) {
-    //Explicitly set these headers and this status.  It's gotta happen.  Make sure it happens.  I'm super serious.
-    res.set("Access-Control-Allow-Origin", "*")
-    res.set("Access-Control-Allow-Headers", "*")
-    res.set("Access-Control-Expose-Headers", "*")
-    res.set("Access-Control-Allow-Methods", "*")
-    res.sendStatus(200)
-}
+ * This module is used for any REST support functionality.  It is used as middleware and so
+ * has access to the http module request and response objects, as well as next()
+ * It is in charge of responding to the client. 
+ * 
+ * @author thehabes 
+ */
 
 /**
  * Since programming languages with HTTP packages don't all support PATCH, we have to detect the workaround.
@@ -36,45 +33,48 @@ exports.checkPatchOverrideSupport = function(req, res){
  * Throughout the routes are certain warning, error, and hard fail scenarios.
  * REST is all about communication.  The response code and the textual body are particular.
  * RERUM is all about being clear.  It will build custom responses sometimes for certain scenarios, will remaining RESTful.
+ * 
+ * Note that the res upstream from this has been converted into err.  res will not have what you are looking for, check err instead. 
  */
 exports.messenger = function(err, req, res, next){
     if (res.headersSent) {
         console.log("Middleware cannot control this error.  Headers are sent.")
         return next(err)
     }
-    const responseCode = err.statusCode
-    const responseMessage = err.statusMessage
-    console.log("I am in messenger with code '"+responseCode+"' and message '"+responseMessage+"'")
+    console.log("In messenger with "+res.statusCode+" and "+res.statusMessage)
+    console.log("In messenger with "+err.statusCode+" and "+err.statusMessage)
     let customResponseBody = {}
-    customResponseBody.http_response_code =  responseCode
-    customResponseBody.message = responseMessage
-    switch (responseCode){
+    let statusCode = err.statusCode ? err.statusCode : res.statusCode ? res.statusCode : 500
+    customResponseBody.http_response_code = statusCode
+    const msgIn = err.statusCode ? err.statusMessage : res.statusMessage
+    let genericMessage = ""
+    switch (statusCode){
         case 400:
             //"Bad Request", most likely because the body and Content-Type are not aligned.  Could be bad JSON.
-            customResponseBody.message = 
+            genericMessage = 
             "The body of your request was invalid. Please make sure it is a valid content-type and that the body matches that type.  "
             +"If the body is JSON, make sure it is valid JSON."
         break
         case 401:
             //The requesting agent is known from the request.  That agent does not match __rerum.generatedBy.  Unauthorized.
-            customResponseBody.message = 
+            genericMessage = 
             "This application is not the generator for the object you are trying to alter.  Fork the object via an update to make changes."
         break
         case 403:
             //Forbidden to use this.  There may not be an Authorization header, or that header is invalid, or the Bearer is not known to RERUM.
             if(res.getHeader("Authorization")){
-                customResponseBody.message = 
+                genericMessage = 
                 "RERUM could not authorize you to perform this action.  The 'Bearer' is not of RERUM.  "
                 +"Make sure you have registered at "+process.env.RERUM_PREFIX
             }
             else{
-                customResponseBody.message = 
+                genericMessage = 
                 "Improper or missing Authorization header provided on request.  Required header must be 'Authorization: Bearer {token}'.  "
                 +"Make sure you have registered at "+process.env.RERUM_PREFIX
             }  
         break
         case 404:
-            customResponseBody.message = 
+            genericMessage = 
                 "The requested web page or resource could not be found."
         break
         case 405:
@@ -82,11 +82,11 @@ exports.messenger = function(err, req, res, next){
         break
         case 500:
             //Really bad, probably not specifically caught.  
-            customResponseBody.message = "RERUM experienced a server issue while performing this action.  "
+            genericMessage = "RERUM experienced a server issue while performing this action.  "
             +"It may not have completed at all, and most likely did not complete successfully."
         case 503:
             //RERUM is down
-            customResponseBody.message = "RERUM v1 is down for updates or maintenance at this time.  "  
+            genericMessage = "RERUM v1 is down for updates or maintenance at this time.  "  
             +"We aplologize for the inconvenience.  Try again later."
             res.redirect(301, "/maintenance.html")
         break
@@ -94,7 +94,6 @@ exports.messenger = function(err, req, res, next){
             //Unsupported messaging scenario for this helper function.  
             //A customized object for the original error will be sent, if res allows it.
     }
-    console.log("Messenger to send custom body")
-    console.log(customResponseBody)
-    res.status(responseCode).send(customResponseBody)
+    customResponseBody.message = msgIn ? msgIn : genericMessage
+    res.status(statusCode).send(customResponseBody)
 }

--- a/rest.js
+++ b/rest.js
@@ -96,6 +96,7 @@ exports.messenger = function(err, req, res, next){
             //RERUM is down
             customResponseBody.message = "RERUM v1 is down for updates or maintenance at this time.  "  
             +"We aplologize for the inconvenience.  Try again later."
+            res.redirect(301, "/maintenance.html")
         break
         default:
             //Unsupported messaging scenario for this helper function.  

--- a/rest.js
+++ b/rest.js
@@ -86,7 +86,7 @@ exports.messenger = function(err, req, res, next){
                 "The requested web page or resource could not be found."
         break
         case 405:
-            //I think these are all handled in api-routes.js already.  Not sure we will do anything custom here
+            //I think these are all handled in api-routes.js already, and won't route here.  Not sure we would do anything custom here anyway.
         break
         case 500:
             //Really bad, probably not specifically caught.  

--- a/rest.js
+++ b/rest.js
@@ -21,7 +21,7 @@
  */
 exports.checkPatchOverrideSupport = function(req, res){
     const override = req.getHeader("X-HTTP-Method-Override")
-    return undefined != override && override.equals("PATCH")
+    return undefined != override && override === "PATCH"
 }
 
 /**

--- a/rest.js
+++ b/rest.js
@@ -14,19 +14,14 @@
  * This is routed to by a res.post() so the request method is ALWAYS POST
  *
  *  X-HTTP-Method-Override header is not present means "no", there is no override support, POST is the wrong method so 405
- *  X-HTTP-Method-Override header is present, !== PATCH means "no", you have done a POST and are not emulating it is as a PATCH, so 405
+ *  X-HTTP-Method-Override header is present, !== PATCH means "no", you have done a POST and are not emulating it as a PATCH, so 405
  *  X-HTTP-Method-Override header is present, == PATCH, and method request is POST means "yes", you are emulating a POST as a PATCH, correct method 200
  *
  *  The error handler sits a level up, so do not res.send() or res.render here.  Just give back a boolean
  */
 exports.checkPatchOverrideSupport = function(req, res){
-    const overrideHeader = req.getHeader("X-HTTP-Method-Override")
-    if(undefined != overrideHeader){
-        if(overrideHeader.equals("PATCH")){
-            return true
-        }
-    }
-    return false
+    const override = req.getHeader("X-HTTP-Method-Override")
+    return undefined != override && override.equals("PATCH")
 }
 
 /**

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -206,7 +206,7 @@ router.route('/api/set')
  * Note that this will track history.
  * Note that keys in the body of this request that are not on the existing object are ignored.  
  * 
- * TODO If there is nothing to PATCH, return a 204 saying as much (this is a warning)
+ * TODO If there is nothing to PATCH, return a 204 saying as much (this is a warning,)
 */ 
 router.route('/api/unset')
     .get((req, res) => {
@@ -224,11 +224,34 @@ router.route('/api/unset')
     .delete((req, res) => {
         res.status(405).send('Improper request method for updating, please use PATCH to remove keys from this object.')
     })
+
 /**
- * Support DELETE request.
- * TODO support this via delete/id/abcde or a post with a body that has an '@id'
- * Note that this will track history.
- * Note that keys in the body of this request that are not on the existing object are ignored.  
+ * Support DELETE requests like an /id/ request, where the id is the thing to delete
+ * Note this needs to be separate from v1/api/delete, so it is just /v1/delete/
+*/ 
+router.route('/delete/:_id')
+    .get((req, res) => {
+        res.status(405).send('Improper request method for deleting, please use DELETE.')
+    })
+    .post((req, res) => {
+        res.status(405).send('Improper request method for deleting, please use DELETE.')
+    })
+    .put((req, res) => {
+        res.status(405).send('Improper request method for deleting, please use DELETE.')
+    })
+    .patch((req, res) => {
+        res.status(405).send('Improper request method for deleting, please use DELETE.')
+    })
+    .options(rest.optionsRequest)
+    .head((req, res) => {
+        res.status(405).send('Improper request method for deleting, please use DELETE.')
+    })
+    .delete(controller.delete)  
+ 
+
+/**
+ * Support DELETE request where there is JSON in the body with a detectable "id"  
+ * NOTE XHR DOES NOT SUPPORT THIS!!!!!
 */ 
 router.route('/api/delete')
     .get((req, res) => {
@@ -247,25 +270,10 @@ router.route('/api/delete')
     .head((req, res) => {
         res.status(405).send('Improper request method for deleting, please use DELETE.')
     })
-    .delete(controller.delete)  
-
-/*
-router.route('/delete/:_id')
-    .get(controller.id)
-    .post((req, res) => {
-        res.status(405).send('Improper method for request by id, please use GET or request for headers with HEAD.')
-    })
-    .put((req, res) => {
-        res.status(405).send('Improper method for request by id, please use GET or request for headers with HEAD.')
-    })
-    .patch((req, res) => {
-        res.status(405).send('Improper method for request by id, please use GET or request for headers with HEAD.')
-    })
-    .options(rest.optionsRequest)
-    .head(controller.idHeadRequest)
     .delete((req, res) => {
-        res.status(405).send('Improper method for request by id, please use GET or request for headers with HEAD.')
-    })  
-  */ 
+        res.status(405).send('HTTP Request bodies with DELETE methods are not allowed.  '  
+        +'Please use URL pattern /v1/delete/{id} and do not pass a body.')
+    }) 
+
 // Export API routes
 module.exports = router

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -314,10 +314,9 @@ router.route('/api/unset')
     })
 
 /**
- * Support DELETE requests like an /id/ request, where the id is the thing to delete
- * Note this needs to be separate from v1/api/delete, so it is just /v1/delete/
+ * DELETE cannot have body.  It is possible to call /delete/ without an id, which will 400.
 */ 
-router.route('/delete/:_id')
+router.route('/api/delete/:_id?')
     .get((req, res) => {
         res.statusMessage = 'Improper request method for deleting, please use DELETE.'
         res.status(405)
@@ -344,49 +343,24 @@ router.route('/delete/:_id')
         next()
     })
     .delete(controller.delete)  
- 
+
 
 /**
- * Support DELETE request where there is JSON in the body with a detectable "id"  
- * NOTE XHR DOES NOT SUPPORT THIS!!!!!
-*/ 
-router.route('/api/delete')
-    .get((req, res) => {
-        res.statusMessage = 'Improper request method for deleting, please use DELETE.'
-        res.status(405)
-        next()
-    })
-    .post((req, res) => {
-        res.statusMessage = 'Improper request method for deleting, please use DELETE.'
-        res.status(405)
-        next()
-    })
-    .put((req, res) => {
-        res.statusMessage = 'Improper request method for deleting, please use DELETE.'
-        res.status(405)
-        next()
-    })
-    .patch((req, res) => {
-        res.statusMessage = 'Improper request method for deleting, please use DELETE.'
-        res.status(405)
-        next()
-    })
-    .head((req, res) => {
-        res.statusMessage = 'Improper request method for deleting, please use DELETE.'
-        res.status(405)
-        next()
-    })
-    .delete((req, res) => {
-        res.statusMessage = 'HTTP Request bodies with DELETE methods are not allowed.  Please use URL pattern /v1/delete/{id} and do not pass a body.'
-        res.status(400)
-        next()
-    }) 
-
-//catch 404 because of an invalid site path inside of /v1/
+ * Use this to catch 404s because of invalid /api/ paths and pass them to the error handler in app.js
+ * 
+ * Note while we have 501s, they will fall here.  Don't let them trick you.
+ * Detect them and send them out, don't hand up to the 404 catcher in app.js
+ */
 router.use(function(req, res, next) {
-    let msg = res.statusMessage ? res.statusMessage : "This page does not exist"
-    res.status(404).send(msg)
-    res.end()
+    if(res.statusCode === 501){
+        //We can remove this once we implement the functions, for now we have to catch it here.
+        let msg = res.statusMessage ? res.statusMessage : "This is not yet implemented"
+        res.status(501).send(msg).end()
+    }
+    else{
+        //A 404 to pass along to our 404 handler in app.js
+        next()
+    }
 })
 
 // Export API routes

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -382,5 +382,12 @@ router.route('/api/delete')
         next()
     }) 
 
+//catch 404 because of an invalid site path inside of /v1/
+router.use(function(req, res, next) {
+    let msg = res.statusMessage ? res.statusMessage : "This page does not exist"
+    res.status(404).send(msg)
+    res.end()
+})
+
 // Export API routes
 module.exports = router

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -1,4 +1,15 @@
 #!/usr/bin/env node
+
+/**
+ * This module is used to define the routes of the various HITTP request that come to the app.
+ * Since this app functions as an API layer, it controls RESTful flows.  Make sure to send a RESTful
+ * status code and response message. 
+ * 
+ * It is used as middleware and so has access to the http module request and response objects, as well as next()
+ * 
+ * @author thehabes 
+ */
+
 const router = require('express').Router()
 //This controller will handle all MongoDB interactions.
 const controller = require('../db-controller.js')
@@ -29,74 +40,93 @@ router.get('/', function (req, res) {
 
 /**
  * Support GET requests like v1/id/{object id}  
- * RESTfully handle bad methods and request bodies.  
- * RESTfully respond in 500 scenarios.
 */
 router.route('/id/:_id')
     .get(controller.id)
     .post((req, res) => {
-        res.status(405).send('Improper method for request by id, please use GET or request for headers with HEAD.')
+        res.statusMessage = 'Improper request method for creating, please use POST.'
+        res.status(405)
+        next()
     })
     .put((req, res) => {
-        res.status(405).send('Improper method for request by id, please use GET or request for headers with HEAD.')
+        res.statusMessage = 'Improper request method for creating, please use POST.'
+        res.status(405)
+        next()
     })
     .patch((req, res) => {
-        res.status(405).send('Improper method for request by id, please use GET or request for headers with HEAD.')
+        res.statusMessage = 'Improper request method for creating, please use POST.'
+        res.status(405)
+        next()
     })
-    .options(rest.optionsRequest)
     .head(controller.idHeadRequest)
     .delete((req, res) => {
-        res.status(405).send('Improper method for request by id, please use GET or request for headers with HEAD.')
+        res.statusMessage = 'Improper request method for creating, please use POST.'
+        res.status(405)
+        next()
     })
 
 /**
  * Support POST requests with JSON bodies used for passing queries though to the database.
- * RESTfully handle bad methods and request bodies.  
- * RESTfully respond in 500 scenarios. 
 */
 router.route('/api/query')
     .get((req, res) => {
-        res.status(405).send('Improper request method for requesting objects with matching properties.  Please use POST.')
+        res.statusMessage = 'Improper request method for requesting objects with matching properties.  Please use POST.'
+        res.status(405)
+        next()
     })
     .post(controller.query)
     .put((req, res) => {
-        res.status(405).send('Improper request method for requesting objects with matching properties.  Please use POST.')
+        res.statusMessage = 'Improper request method for requesting objects with matching properties.  Please use POST.'
+        res.status(405)
+        next()
     })
     .patch((req, res) => {
-        res.status(405).send('Improper request method for requesting objects with matching properties.  Please use POST.')
-    })
-    .options(rest.optionsRequest)
-    .head((req, res) => {
-        res.status(405).send('Improper request method for requesting objects with matching properties.  Please use POST.')
-    })
-    .delete((req, res) => {
-        res.status(405).send('Improper request method for requesting objects with matching properties.  Please use POST.')
+        res.statusMessage = 'Improper request method for requesting objects with matching properties.  Please use POST.'
+        res.status(405)
+        next()
     })
     //Do we want to support this? Technically HEAD is only for something that could be a GET request.  
     //.head(controller.queryHeadRequest)
+    .head((req, res) => {
+        res.statusMessage = 'Improper request method for requesting objects with matching properties.  Please use POST.'
+        res.status(405)
+        next()
+    })
+    .delete((req, res) => {
+        res.statusMessage = 'Improper request method for requesting objects with matching properties.  Please use POST.'
+        res.status(405)
+        next()
+    })
 
 /**
  * Support POST requests with JSON bodies used for establishing new objects in the MongoDB.
- * RESTfully handle bad methods and request bodies.  
- * RESTfully respond in 500 scenarios. 
 */
 router.route('/api/create')
     .get((req, res) => {
-        res.status(405).send('Improper request method for creating, please use POST.')
+        res.statusMessage = 'Improper request method for creating, please use POST.'
+        res.status(405)
+        next()
     })
     .post(controller.create)
     .put((req, res) => {
-        res.status(405).send('Improper request method for creating, please use POST.')
+        res.statusMessage = 'Improper request method for creating, please use POST.'
+        res.status(405)
+        next()
     })
     .patch((req, res) => {
-        res.status(405).send('Improper request method for creating, please use POST.')
+        res.statusMessage = 'Improper request method for creating, please use POST.'
+        res.status(405)
+        next()
     })
-    .options(rest.optionsRequest)
     .head((req, res) => {
-        res.status(405).send('Improper request method for creating, please use POST.')
+        res.statusMessage = 'Improper request method for creating, please use POST.'
+        res.status(405)
+        next()
     })
     .delete((req, res) => {
-        res.status(405).send('Improper request method for creating, please use POST.')
+        res.statusMessage = 'Improper request method for creating, please use POST.'
+        res.status(405)
+        next()
     })
 
 /**
@@ -105,21 +135,30 @@ router.route('/api/create')
 */
 router.route('/api/overwrite')
     .get((req, res) => {
-        res.status(405).send('Improper request method for overwriting, please use PUT to overwrite this object.')
+        res.statusMessage = 'Improper request method for overwriting, please use PUT to overwrite this object.'
+        res.status(405)
+        next()
     })
     .post((req, res) => {
-        res.status(405).send('Improper request method for overwriting, please use PUT to overwrite this object.')
+        res.statusMessage = 'Improper request method for overwriting, please use PUT to overwrite this object.'
+        res.status(405)
+        next()
     })
     .put(controller.overwrite)
     .patch((req, res) => {
-        res.status(405).send('Improper request method for overwriting, please use PUT to overwrite this object.')
+        res.statusMessage = 'Improper request method for overwriting, please use PUT to overwrite this object.'
+        res.status(405)
+        next()
     })
-    .options(rest.optionsRequest)
     .head((req, res) => {
-        res.status(405).send('Improper request method for overwriting, please use PUT to overwrite this object.')
+        res.statusMessage = 'Improper request method for overwriting, please use PUT to overwrite this object.'
+        res.status(405)
+        next()
     })
     .delete((req, res) => {
-        res.status(405).send('Improper request method for overwriting, please use PUT to overwrite this object.')
+        res.statusMessage = 'Improper request method for overwriting, please use PUT to overwrite this object.'
+        res.status(405)
+        next()
     })
     
 
@@ -129,21 +168,30 @@ router.route('/api/overwrite')
 */ 
 router.route('/api/update')
     .get((req, res) => {
-        res.status(405).send('Improper request method for updating, please use PUT to update this object.')
+        res.statusMessage = 'Improper request method for updating, please use PUT to update this object.'
+        res.status(405)
+        next()
     })
     .post((req, res) => {
-        res.status(405).send('Improper request method for updating, please use PUT to update this object.')
+        res.statusMessage = 'Improper request method for updating, please use PUT to update this object.'
+        res.status(405)
+        next()
     })
     .put(controller.putUpdate)
     .patch((req, res) => {
-        res.status(405).send('Improper request method for updating, please use PUT to update this object.')
+        res.statusMessage = 'Improper request method for updating, please use PUT to update this object.'
+        res.status(405)
+        next()
     })
-    .options(rest.optionsRequest)
     .head((req, res) => {
-        res.status(405).send('Improper request method for updating, please use PUT to update this object.')
+        res.statusMessage = 'Improper request method for updating, please use PUT to update this object.'
+        res.status(405)
+        next()
     })
     .delete((req, res) => {
-        res.status(405).send('Improper request method for updating, please use PUT to update this object.')
+        res.statusMessage = 'Improper request method for updating, please use PUT to update this object.'
+        res.status(405)
+        next()
     })
 
 /**
@@ -151,30 +199,39 @@ router.route('/api/update')
  * Note that this will track history.
  * Note that keys in the body of this request that are not on the existing object are ignored.  
  * 
- * TODO If there is nothing to PATCH, return a 204 saying as much (this is a warning)
+ * If there is nothing to PATCH, return a 200 
 */ 
 router.route('/api/patch')
     .get((req, res) => {
-        res.status(405).send('Improper request method for updating, please use PATCH to alter existing keys on this object.')
+        res.statusMessage = 'Improper request method for updating, please use PATCH to alter existing keys on this object.'
+        res.status(405)
+        next()
     })
     .post((req, res) => {
         if(rest.checkPatchOverrideSupport()){
             controller.patchUpdate(req, resp)
         }
         else{
-            res.status(405).send('Improper request method for updating, please use PATCH to alter existing keys on this object.')    
+            res.statusMessage = 'Improper request method for updating, please use PATCH to alter existing keys on this object.'
+            res.status(405)
+            next()    
         }
     })
     .put((req, res) => {
-        res.status(405).send('Improper request method for updating, please use PATCH to alter existing keys on this object.')
+        res.statusMessage = 'Improper request method for updating, please use PATCH to alter existing keys on this object.'
+        res.status(405)
+        next()
     })
-    .patch(controller.patchSet)
-    .options(rest.optionsRequest)
+    .patch(controller.patchUpdate)
     .head((req, res) => {
-        res.status(405).send('Improper request method for updating, please use PATCH to alter existing keys on this object.')
+        res.statusMessage = 'Improper request method for updating, please use PATCH to alter existing keys on this object.'
+        res.status(405)
+        next()
     })
     .delete((req, res) => {
-        res.status(405).send('Improper request method for updating, please use PATCH to alter existing keys on this object.')
+        res.statusMessage = 'Improper request method for updating, please use PATCH to alter existing keys on this object.'
+        res.status(405)
+        next()
     })
 
 /**
@@ -182,23 +239,38 @@ router.route('/api/patch')
  * Note that this will track history.
  * Note that keys in the body of this request that are already on the existing object are ignored.   
  * 
- * TODO If there is nothing to PATCH, return a 204 saying as much (this is a warning)
+ * If there is nothing to PATCH, return a 200 
 */ 
 router.route('/api/set')
     .get((req, res) => {
-        res.status(405).send('Improper request method for updating, please use PATCH to add new keys object.')
+        res.statusMessage = 'Improper request method for updating, please use PATCH to add new keys to this object.'
+        res.status(405)
+        next()
     })
-    .post(rest.checkPatchOverrideSupport)
+    .post((req, res) => {
+        if(rest.checkPatchOverrideSupport()){
+            controller.patchSet(req, resp)
+        }
+        else{
+            res.statusMessage = 'Improper request method for updating, please use PATCH to add new keys to this object.'
+            res.status(405)
+            next()    
+        }
+    })
     .put((req, res) => {
-        res.status(405).send('Improper request method for updating, please use PATCH to add new keys object.')
-    })
+        res.statusMessage = 'Improper request method for updating, please use PATCH to add new keys to this object.'
+        res.status(405)
+        next()    })
     .patch(controller.patchSet)
-    .options(rest.optionsRequest)
     .head((req, res) => {
-        res.status(405).send('Improper request method for updating, please use PATCH to add new keys object.')
+        res.statusMessage = 'Improper request method for updating, please use PATCH to add new keys to this object.'
+        res.status(405)
+        next()
     })
     .delete((req, res) => {
-        res.status(405).send('Improper request method for updating, please use PATCH to add new keys object.')
+        res.statusMessage = 'Improper request method for updating, please use PATCH to add new keys to this object.'
+        res.status(405)
+        next()
     })
 
 /**
@@ -206,23 +278,39 @@ router.route('/api/set')
  * Note that this will track history.
  * Note that keys in the body of this request that are not on the existing object are ignored.  
  * 
- * TODO If there is nothing to PATCH, return a 204 saying as much (this is a warning,)
+ * If there is nothing to PATCH, return a 200 
 */ 
 router.route('/api/unset')
     .get((req, res) => {
-        res.status(405).send('Improper request method for updating, please use PATCH to remove keys from this object.')
+        res.statusMessage = 'Improper request method for updating, please use PATCH to remove keys from this object.'
+        res.status(405)
+        next()
     })
-    .post(rest.checkPatchOverrideSupport)
+    .post((req, res) => {
+        if(rest.checkPatchOverrideSupport()){
+            controller.patchUnset(req, resp)
+        }
+        else{
+            res.statusMessage = 'Improper request method for updating, please use PATCH to remove keys from this object.'
+            res.status(405)
+            next()    
+        }
+    })
     .put((req, res) => {
-        res.status(405).send('Improper request method for updating, please use PATCH to remove keys from this object.')
+        res.statusMessage = 'Improper request method for updating, please use PATCH to remove keys from this object.'
+        res.status(405)
+        next()
     })
     .patch(controller.patchUnset)
-    .options(rest.optionsRequest)
     .head((req, res) => {
-        res.status(405).send('Improper request method for updating, please use PATCH to remove keys from this object.')
+        res.statusMessage = 'Improper request method for updating, please use PATCH to remove keys from this object.'
+        res.status(405)
+        next()
     })
     .delete((req, res) => {
-        res.status(405).send('Improper request method for updating, please use PATCH to remove keys from this object.')
+        res.statusMessage = 'Improper request method for updating, please use PATCH to remove keys from this object.'
+        res.status(405)
+        next()
     })
 
 /**
@@ -231,20 +319,29 @@ router.route('/api/unset')
 */ 
 router.route('/delete/:_id')
     .get((req, res) => {
-        res.status(405).send('Improper request method for deleting, please use DELETE.')
+        res.statusMessage = 'Improper request method for deleting, please use DELETE.'
+        res.status(405)
+        next()
     })
     .post((req, res) => {
-        res.status(405).send('Improper request method for deleting, please use DELETE.')
+        res.statusMessage = 'Improper request method for deleting, please use DELETE.'
+        res.status(405)
+        next()
     })
     .put((req, res) => {
-        res.status(405).send('Improper request method for deleting, please use DELETE.')
+        res.statusMessage = 'Improper request method for deleting, please use DELETE.'
+        res.status(405)
+        next()
     })
     .patch((req, res) => {
-        res.status(405).send('Improper request method for deleting, please use DELETE.')
+        res.statusMessage = 'Improper request method for deleting, please use DELETE.'
+        res.status(405)
+        next()
     })
-    .options(rest.optionsRequest)
     .head((req, res) => {
-        res.status(405).send('Improper request method for deleting, please use DELETE.')
+        res.statusMessage = 'Improper request method for deleting, please use DELETE.'
+        res.status(405)
+        next()
     })
     .delete(controller.delete)  
  
@@ -255,24 +352,34 @@ router.route('/delete/:_id')
 */ 
 router.route('/api/delete')
     .get((req, res) => {
-        res.status(405).send('Improper request method for deleting, please use DELETE.')
+        res.statusMessage = 'Improper request method for deleting, please use DELETE.'
+        res.status(405)
+        next()
     })
     .post((req, res) => {
-        res.status(405).send('Improper request method for deleting, please use DELETE.')
+        res.statusMessage = 'Improper request method for deleting, please use DELETE.'
+        res.status(405)
+        next()
     })
     .put((req, res) => {
-        res.status(405).send('Improper request method for deleting, please use DELETE.')
+        res.statusMessage = 'Improper request method for deleting, please use DELETE.'
+        res.status(405)
+        next()
     })
     .patch((req, res) => {
-        res.status(405).send('Improper request method for deleting, please use DELETE.')
+        res.statusMessage = 'Improper request method for deleting, please use DELETE.'
+        res.status(405)
+        next()
     })
-    .options(rest.optionsRequest)
     .head((req, res) => {
-        res.status(405).send('Improper request method for deleting, please use DELETE.')
+        res.statusMessage = 'Improper request method for deleting, please use DELETE.'
+        res.status(405)
+        next()
     })
     .delete((req, res) => {
-        res.status(405).send('HTTP Request bodies with DELETE methods are not allowed.  '  
-        +'Please use URL pattern /v1/delete/{id} and do not pass a body.')
+        res.statusMessage = 'HTTP Request bodies with DELETE methods are not allowed.  Please use URL pattern /v1/delete/{id} and do not pass a body.'
+        res.status(400)
+        next()
     }) 
 
 // Export API routes

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -150,6 +150,8 @@ router.route('/api/update')
  * Support PATCH requests with JSON bodies used for replacing some existing keys in some existing object in MongoDB.
  * Note that this will track history.
  * Note that keys in the body of this request that are not on the existing object are ignored.  
+ * 
+ * TODO If there is nothing to PATCH, return a 204 saying as much (this is a warning)
 */ 
 router.route('/api/patch')
     .get((req, res) => {
@@ -179,6 +181,8 @@ router.route('/api/patch')
  * Support PATCH requests with JSON bodies used for creating new keys in some existing object in MongoDB.
  * Note that this will track history.
  * Note that keys in the body of this request that are already on the existing object are ignored.   
+ * 
+ * TODO If there is nothing to PATCH, return a 204 saying as much (this is a warning)
 */ 
 router.route('/api/set')
     .get((req, res) => {
@@ -201,6 +205,8 @@ router.route('/api/set')
  * Support PATCH requests with JSON bodies like 'key:null' used for removing existing keys from some existing object in MongoDB.
  * Note that this will track history.
  * Note that keys in the body of this request that are not on the existing object are ignored.  
+ * 
+ * TODO If there is nothing to PATCH, return a 204 saying as much (this is a warning)
 */ 
 router.route('/api/unset')
     .get((req, res) => {
@@ -219,7 +225,8 @@ router.route('/api/unset')
         res.status(405).send('Improper request method for updating, please use PATCH to remove keys from this object.')
     })
 /**
- * Support PATCH requests with JSON bodies like 'key:null' used for removing existing keys from some existing object in MongoDB.
+ * Support DELETE request.
+ * TODO support this via delete/id/abcde or a post with a body that has an '@id'
  * Note that this will track history.
  * Note that keys in the body of this request that are not on the existing object are ignored.  
 */ 
@@ -240,7 +247,25 @@ router.route('/api/delete')
     .head((req, res) => {
         res.status(405).send('Improper request method for deleting, please use DELETE.')
     })
-    .delete(controller.delete)    
-   
+    .delete(controller.delete)  
+
+/*
+router.route('/delete/:_id')
+    .get(controller.id)
+    .post((req, res) => {
+        res.status(405).send('Improper method for request by id, please use GET or request for headers with HEAD.')
+    })
+    .put((req, res) => {
+        res.status(405).send('Improper method for request by id, please use GET or request for headers with HEAD.')
+    })
+    .patch((req, res) => {
+        res.status(405).send('Improper method for request by id, please use GET or request for headers with HEAD.')
+    })
+    .options(rest.optionsRequest)
+    .head(controller.idHeadRequest)
+    .delete((req, res) => {
+        res.status(405).send('Improper method for request by id, please use GET or request for headers with HEAD.')
+    })  
+  */ 
 // Export API routes
 module.exports = router


### PR DESCRIPTION
Created a messenger in the rest.js module.

I added the rest.messenger() function as the middleware for error handling (in app.js).  If something happens to not be handled in the messenger, it will fail out to a generic 500 with generic message.  I did not find a way to trigger this behavior, but someone will some day.

try-catch in the db-controller was useless.  Express handling takes precedence, which is why those all went way.  They were never reached; it always fails to the error handler (now `rest.messenger`), never the catch().  See the code documentation, it is insightful.

Jest tests were not written :(

Manually tested and working. 