### PR TITLE
Order Properties and Support Slugs

### DIFF
--- a/db-controller.js
+++ b/db-controller.js
@@ -117,8 +117,8 @@ exports.delete = async function (req, res, next) {
         deletedFlag["time"] = new Date(Date.now()).toISOString().replace("Z", "")
         let deletedObject = {
             "@id": preserveID,
-            "__deleted": deletedFlag
-            "_id" : id,
+            "__deleted": deletedFlag,
+            "_id" : id
         }
         if (healHistoryTree(safe_received)) {
             let result

--- a/db-controller.js
+++ b/db-controller.js
@@ -38,7 +38,6 @@ exports.create = async function (req, res, next) {
     let rerumProp = utils.configureRerumOptions(generatorAgent, provided, false, false)
     let newObject = Object.assign(context, {"@id":process.env.RERUM_ID_PREFIX + id}, provided, rerumProp, {"_id":id})
     console.log("CREATE")
-    console.log(newObject)
     try {
         let result = await client.db(process.env.MONGODBNAME).collection(process.env.MONGODBCOLLECTION).insertOne(newObject)
         res.set(utils.configureWebAnnoHeadersFor(newObject))

--- a/db-controller.js
+++ b/db-controller.js
@@ -47,7 +47,18 @@ exports.create = async function (req, res, next) {
         res.json(newObject)
     }
     catch (error) {
-        //WriteError or WriteConcernError
+        //MongoServerError from the client has the following properties: index, code, keyPattern, keyValue
+        if(error.code){
+            if(error.code === 11000){
+                //Duplicate _id key error, specific to SLUG support.  This is a Conflict or a Bad Request.
+                let err = {
+                    "status":409,
+                    "message":`The id provided in the Slug header ${id} already exists.  Please use a different Slug.`
+                }
+                next(createExpressError(err))
+                return
+            }
+        }
         next(createExpressError(error))
     }
 }

--- a/db-controller.js
+++ b/db-controller.js
@@ -110,7 +110,6 @@ exports.delete = async function (req, res, next) {
                 status: 401
             })
         }
-
         if (err.status) {
             next(createExpressError(err))
             return
@@ -167,7 +166,6 @@ exports.putUpdate = async function (req, res, next) {
     let err = { message: `` }
     res.set("Content-Type", "application/json; charset=utf-8")
     let objectReceived = JSON.parse(JSON.stringify(req.body))
-    //A token came in with this request.  We need the agent from it.  
     let generatorAgent = req.user[process.env.RERUM_AGENT_CLAIM] ?? "http://dev.rerum.io/agent/CANNOTBESTOPPED"
     if (objectReceived["@id"]) {
         let updateHistoryNextID = objectReceived["@id"]
@@ -196,7 +194,6 @@ exports.putUpdate = async function (req, res, next) {
         else {
             const id = new ObjectID().toHexString()            
             let context = objectReceived["@context"]?{"@context":objectReceived["@context"]}:{}
-            //A bit goofy here, we actually just want the resulting __rerum. It needed data from objectReceived to build itself.  
             let rerumProp = {"__rerum":utils.configureRerumOptions(generatorAgent, originalObject, true, false)["__rerum"]}
             delete objectReceived["_rerum"]
             delete objectReceived["_id"]
@@ -249,7 +246,6 @@ exports.patchUpdate = async function (req, res, next) {
     res.set("Content-Type", "application/json; charset=utf-8")
     let objectReceived = JSON.parse(JSON.stringify(req.body))
     let patchedObject = {}
-    //A token came in with this request.  We need the agent from it.  
     let generatorAgent = req.user[process.env.RERUM_AGENT_CLAIM] ?? "http://dev.rerum.io/agent/CANNOTBESTOPPED"
     if (objectReceived["@id"]) {
         let updateHistoryNextID = objectReceived["@id"]
@@ -306,7 +302,6 @@ exports.patchUpdate = async function (req, res, next) {
             }
             const id = new ObjectID().toHexString()            
             let context = patchedObject["@context"]?{"@context":patchedObject["@context"]}:{}
-            //A bit goofy here, we actually just want the resulting __rerum. It needed data from objectReceived to build itself.  
             let rerumProp = {"__rerum":utils.configureRerumOptions(generatorAgent, originalObject, true, false)["__rerum"]}
             delete patchedObject["_rerum"]
             delete patchedObject["_id"]
@@ -359,7 +354,6 @@ exports.patchSet = async function (req, res, next) {
     res.set("Content-Type", "application/json; charset=utf-8")
     let objectReceived = JSON.parse(JSON.stringify(req.body))
     let patchedObject = {}
-    //A token came in with this request.  We need the agent from it.  
     let generatorAgent = req.user[process.env.RERUM_AGENT_CLAIM] ?? "http://dev.rerum.io/agent/CANNOTBESTOPPED"
     if (objectReceived["@id"]) {
         let updateHistoryNextID = objectReceived["@id"]
@@ -408,7 +402,6 @@ exports.patchSet = async function (req, res, next) {
             }
             const id = new ObjectID().toHexString()            
             let context = patchedObject["@context"]?{"@context":patchedObject["@context"]}:{}
-            //A bit goofy here, we actually just want the resulting __rerum. It needed data from objectReceived to build itself.  
             let rerumProp = {"__rerum":utils.configureRerumOptions(generatorAgent, originalObject, true, false)["__rerum"]}
             delete patchedObject["_rerum"]
             delete patchedObject["_id"]
@@ -460,7 +453,6 @@ exports.patchUnset = async function (req, res, next) {
     res.set("Content-Type", "application/json; charset=utf-8")
     let objectReceived = JSON.parse(JSON.stringify(req.body))
     let patchedObject = {}
-    //A token came in with this request.  We need the agent from it.  
     let generatorAgent = req.user[process.env.RERUM_AGENT_CLAIM] ?? "http://dev.rerum.io/agent/CANNOTBESTOPPED"
     if (objectReceived["@id"]) {
         let updateHistoryNextID = objectReceived["@id"]
@@ -516,7 +508,6 @@ exports.patchUnset = async function (req, res, next) {
             }
             const id = new ObjectID().toHexString()            
             let context = patchedObject["@context"]?{"@context":patchedObject["@context"]}:{}
-            //A bit goofy here, we actually just want the resulting __rerum. It needed data from objectReceived to build itself.  
             let rerumProp = {"__rerum":utils.configureRerumOptions(generatorAgent, originalObject, true, false)["__rerum"]}
             delete patchedObject["_rerum"]
             delete patchedObject["_id"]
@@ -603,9 +594,8 @@ exports.overwrite = async function (req, res, next) {
         }
         else {
             let context = objectReceived["@context"]?{"@context":objectReceived["@context"]}:{}
-            //A bit goofy here, we actually just want the resulting __rerum. It needed data from objectReceived to build itself.  
             let rerumProp = {"__rerum":originalObject["__rerum"]}
-            rerumProp.isOverwritten = new Date(Date.now()).toISOString().replace("Z", "")
+            rerumProp["__rerum"].isOverwritten = new Date(Date.now()).toISOString().replace("Z", "")
             const id = originalObject["_id"]        
             //Get rid of them so we can enforce the order
             delete objectReceived["@id"]


### PR DESCRIPTION
Detect Slug headers, and specifically detect when they cause a duplicate `_id` error, responding restfully.

Got the property ordering working in /create.  Need to apply the same Object.assign() technique to the PUT and PATCH updates still.