### PR TITLE
Simple documentation fix

### DIFF
--- a/public/API.html
+++ b/public/API.html
@@ -289,7 +289,7 @@
         <p> 
             <div class="exHeading">Example for Getting an Application Access Token</div>
             <pre><code class="jsExample"> 
-                <span>const access_token = await fetch("https://devstore.rerum.io/v1/client/request-new-access-token", {</span>
+                <span>const access_token = await fetch("https://devstore.rerum.io/client/request-new-access-token", {</span>
                     <span class="ind1">method: "POST",</span>
                     <span class="ind1">headers:{</span>
                         <span class="ind2">"Content-Type": "application/json; charset=utf-8"</span>


### PR DESCRIPTION
Fixed documentation to change `devstore.rerum.io/v1/client/request-new-access-token` to `devstore.rerum.io/client/request-new-access-token`. Fixes Issue #154 .