### PR TITLE
/verify endpoint hotfix

### DIFF
--- a/routes/client.js
+++ b/routes/client.js
@@ -1,6 +1,7 @@
 import express from 'express'
 const router = express.Router()
 import auth from '../auth/index.js'
+import { getAgentClaim } from '../controllers/utils.js'
 
 router.get('/register', (req, res, next) => {
   //Register means register with the RERUM Server Auth0 client and get a new code for a refresh token.
@@ -18,6 +19,13 @@ router.get('/register', (req, res, next) => {
 
 router.post('/request-new-access-token',auth.generateNewAccessToken)
 router.post('/request-new-refresh-token',auth.generateNewRefreshToken)
-router.get('/verify',auth.checkJwt)
+
+// Verifies good tokens are from RERUM.  Fails with 401 on tokens from other platforms, or bad tokens in genreal.
+router.get('/verify', auth.checkJwt, (req, res, next) => {
+  const generatorAgent = getAgentClaim(req, next)
+  res.set("Content-Type", "text/plain")
+  res.status(200)
+  res.send("The token was verified by Auth0")
+})
 
 export default router


### PR DESCRIPTION
It was giving 404 because it was not correctly registered as a route.  It is now register in the (req, res, next) flow.

Shout out to @jackcrane and @Devayani1612 for reporting and demoing the odd behavior.  