### PR TITLE
Clean up cache implementation: 

### DIFF
--- a/cache/middleware.js
+++ b/cache/middleware.js
@@ -224,12 +224,12 @@ const invalidateCache = (req, res, next) => {
                 const primeId = extractId(updatedObject?.__rerum?.history?.prime)
 
                 if (!invalidatedKeys.has(`id:${objIdShort}`)) {
-                    cache.delete(`id:${objIdShort}`, true)
+                    cache.delete(`id:${objIdShort}`)
                     invalidatedKeys.add(`id:${objIdShort}`)
                 }
 
                 if (previousId && previousId !== 'root' && !invalidatedKeys.has(`id:${previousId}`)) {
-                    cache.delete(`id:${previousId}`, true)
+                    cache.delete(`id:${previousId}`)
                     invalidatedKeys.add(`id:${previousId}`)
                 }
 
@@ -261,12 +261,12 @@ const invalidateCache = (req, res, next) => {
                 const primeId = extractId(deletedObject?.__rerum?.history?.prime)
 
                 if (!invalidatedKeys.has(`id:${objIdShort}`)) {
-                    cache.delete(`id:${objIdShort}`, true)
+                    cache.delete(`id:${objIdShort}`)
                     invalidatedKeys.add(`id:${objIdShort}`)
                 }
 
                 if (previousId && previousId !== 'root' && !invalidatedKeys.has(`id:${previousId}`)) {
-                    cache.delete(`id:${previousId}`, true)
+                    cache.delete(`id:${previousId}`)
                     invalidatedKeys.add(`id:${previousId}`)
                 }
 
@@ -287,15 +287,11 @@ const invalidateCache = (req, res, next) => {
     }
 
     res.json = async (data) => {
-        // Add worker ID header for debugging cache sync
-        res.set('X-Worker-ID', process.env.pm_id || process.pid)
         await performInvalidation(data)
         return originalJson(data)
     }
 
     res.send = async (data) => {
-        // Add worker ID header for debugging cache sync
-        res.set('X-Worker-ID', process.env.pm_id || process.pid)
         await performInvalidation(data)
         return originalSend(data)
     }


### PR DESCRIPTION
remove unused code and deprecated parmeters

- Remove X-Worker-ID debug headers from middleware response interceptors
- Remove unused timing variables (startTime, workerId, duration, clusterGetDuration) from delete() and invalidateByObject() methods
- Remove deprecated countAsInvalidation parameter from delete() method signature
- Remove countAsInvalidation arguments from all 6 call sites (2 in index.js, 4 in middleware.js)

All changes are code cleanup only - no functional changes. Tests: 54/54 passing in cache.test.js