### PR TITLE
Set slug property only if defined in create and release

### DIFF
--- a/controllers/crud.js
+++ b/controllers/crud.js
@@ -15,7 +15,7 @@ import { _contextid, idNegotiation, generateSlugId, ObjectID, createExpressError
  * */
 const create = async function (req, res, next) {
     res.set("Content-Type", "application/json; charset=utf-8")
-    let slug = null
+    let slug
     if(req.get("Slug")){
         let slug_json = await generateSlugId(req.get("Slug"), next)
         if(slug_json.code){
@@ -31,7 +31,9 @@ const create = async function (req, res, next) {
     let context = req.body["@context"] ? { "@context": req.body["@context"] } : {}
     let provided = JSON.parse(JSON.stringify(req.body))
     let rerumProp = { "__rerum": utils.configureRerumOptions(generatorAgent, provided, false, false)["__rerum"] }
-    rerumProp.__rerum.slug = slug
+    if(slug){
+        rerumProp.__rerum.slug = slug
+    }
     const providedID = provided._id
     const id = isValidID(providedID) ? providedID : ObjectID()
     delete provided["__rerum"]

--- a/controllers/release.js
+++ b/controllers/release.js
@@ -23,7 +23,7 @@ import { _contextid, ObjectID, createExpressError, getAgentClaim, parseDocumentI
 const release = async function (req, res, next) {
     let agentRequestingRelease = getAgentClaim(req, next)
     let id = req.params["_id"]
-    let slug = null
+    let slug
     let err = {"message":""}
     let treeHealed = false
     if(req.get("Slug")){
@@ -75,7 +75,9 @@ const release = async function (req, res, next) {
         if (null !== originalObject){
             safe_original["__rerum"].isReleased = new Date(Date.now()).toISOString().replace("Z", "")
             safe_original["__rerum"].releases.replaces = previousReleasedID
-            safe_original["__rerum"].slug = slug
+            if(slug){
+                safe_original["__rerum"].slug = slug
+            }
             if (previousReleasedID !== "") {
                 // A releases tree exists and an ancestral object is being released.
                 treeHealed = await healReleasesTree(safe_original)


### PR DESCRIPTION
Updated the create and release controllers to assign the __rerum.slug property only when a slug value is present. This prevents undefined slugs from being set in the object metadata.