### PR TITLE
/gog/id/:_id expand endpoint for GoG Data

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,6 +10,7 @@ import apiRouter from './routes/api-routes.js'
 import clientRouter from './routes/client.js'
 import _gog_fragmentsRouter from './routes/_gog_fragments_from_manuscript.js';
 import _gog_glossesRouter from './routes/_gog_glosses_from_manuscript.js';
+import _gog_idRouter from './routes/_gog_id.js';
 import rest from './rest.js'
 import { fileURLToPath } from 'url'
 const __filename = fileURLToPath(import.meta.url)
@@ -83,6 +84,7 @@ app.use('/client', clientRouter)
 
 app.use('/gog/fragmentsInManuscript', _gog_fragmentsRouter)
 app.use('/gog/glossesInManuscript', _gog_glossesRouter)
+app.use('/gog/id', _gog_idRouter)
 
 /**
  * Handle API errors and warnings RESTfully.  All routes that don't end in res.send() will end up here.

--- a/controllers/gog.js
+++ b/controllers/gog.js
@@ -327,7 +327,8 @@ const _gog_glosses_from_manuscript = async function (req, res, next) {
 *
 */
 const expand = async function(primitiveEntity, GENERATOR=undefined, CREATOR=undefined){
-    if(!primitiveEntity?.["@id"] || primitiveEntity?.id) return primitiveEntity
+    // An entity is expandable if it carries a URI under either '@id' or 'id'.
+    if(!primitiveEntity?.["@id"] && !primitiveEntity?.id) return primitiveEntity
     const targetId = primitiveEntity["@id"] ?? primitiveEntity.id ?? "unknown"
     let queryObj = {
         "__rerum.history.next": { $exists: true, $size: 0 }
@@ -386,18 +387,70 @@ const expand = async function(primitiveEntity, GENERATOR=undefined, CREATOR=unde
         return o
     })
 
-    // Combine the Annotation bodies with the primitive object
+    // Combine the Annotation bodies with the primitive object.
+    // Mirror DEER's client-side expand() (deer-utils.js buildValueObject): every asserted value
+    // becomes a { value, source, evidence } object so the front end reads the server-expanded
+    // object exactly as it read the old client-expanded one (e.g. gloss.text.value.textValue).
+    // When more than one current Annotation asserts the same key, collect the values into an Array.
     let expandedEntity = structuredClone(primitiveEntity)
     for(const anno of matches){
         const body = anno.body
-        let keys = Object.keys(body)
-        if(!keys || keys.length !== 1) return
-        let key = keys[0]
-        let val = body[key].value ?? body[key]
-        expandedEntity[key] = val
+        if(!body || typeof body !== "object") continue
+        const keys = Object.keys(body)
+        if(keys.length !== 1) continue
+        const key = keys[0]
+        const assertion = body[key]
+        const valueObject = {
+            value: assertion?.value ?? assertion,
+            source: assertion?.source ?? {
+                citationSource: anno["@id"] ?? anno.id,
+                citationNote: anno.label ?? anno.name ?? "Composed object from DEER",
+                comment: "Learn about the assembler for this object at https://github.com/CenterForDigitalHumanities/deer"
+            },
+            evidence: assertion?.evidence ?? anno.evidence ?? ""
+        }
+        if(expandedEntity.hasOwnProperty(key)){
+            expandedEntity[key] = Array.isArray(expandedEntity[key])
+                ? [...expandedEntity[key], valueObject]
+                : [expandedEntity[key], valueObject]
+        }
+        else{
+            expandedEntity[key] = valueObject
+        }
     }
 
     return expandedEntity
 }
 
-export { _gog_fragments_from_manuscript, _gog_glosses_from_manuscript, expand }
+/**
+ * GET /v1/id/:_id/expanded
+ * Return the RERUM object for :_id with the descriptive Annotations targeting it already merged in
+ * (a server-side expand()).  Because the URL is stable, the response is browser-cacheable, so the
+ * front end can fetch a finished object and does NOT need to expand() it client-side (issue #310).
+ * Mirrors the caching/negotiation behavior of the GET /v1/id/:_id handler in controllers/crud.js.
+ * */
+const expandedId = async function (req, res, next) {
+    res.set("Content-Type", "application/json; charset=utf-8")
+    const id = req.params["_id"]
+    try {
+        let match = await db.findOne({ "$or": [{ "_id": id }, { "__rerum.slug": id }] })
+        if (!match) {
+            const err = { "message": `No RERUM object with id '${id}'`, "status": 404 }
+            return next(utils.createExpressError(err))
+        }
+        // Same browser-caching policy as GET /v1/id/:_id so this stable URI is cached (24h).
+        res.set(utils.configureWebAnnoHeadersFor(match))
+        res.set("Cache-Control", "max-age=86400, must-revalidate")
+        res.set(utils.configureLastModifiedHeader(match))
+        // No GENERATOR/CREATOR filter: merge every current targeting Annotation, matching the
+        // client's historical expand() behavior (its checkMatch is short-circuited to true).
+        let expanded = await expand(match)
+        expanded = idNegotiation(expanded)
+        res.location(_contextid(expanded["@context"]) ? expanded.id : expanded["@id"])
+        res.json(expanded)
+    } catch (error) {
+        return next(utils.createExpressError(error))
+    }
+}
+
+export { _gog_fragments_from_manuscript, _gog_glosses_from_manuscript, expand, expandedId }

--- a/controllers/gog.js
+++ b/controllers/gog.js
@@ -381,7 +381,9 @@ const expand = async function(primitiveEntity, GENERATOR=undefined, CREATOR=unde
     }
 
     // Get the Annotations targeting this Entity from the db.  Remove _id property.
-    let matches = await db.find(queryObj).toArray()
+    // Cap the read for parity with the client's historical findByTargetId (limit=100), which
+    // also bounds the query for pathological high-fan-in objects.
+    let matches = await db.find(queryObj).limit(100).toArray()
     matches = matches.map(o => {
         delete o._id
         return o
@@ -443,6 +445,8 @@ const expandedId = async function (req, res, next) {
         res.set(utils.configureWebAnnoHeadersFor(match))
         res.set("Cache-Control", "max-age=86400, must-revalidate")
         res.set(utils.configureLastModifiedHeader(match))
+        // Include current version for optimistic locking (parity with GET /v1/id/:_id)
+        res.set("Current-Overwritten-Version", match.__rerum?.isOverwritten ?? "")
         // No GENERATOR/CREATOR filter: merge every current targeting Annotation, matching the
         // client's historical expand() behavior (its checkMatch is short-circuited to true).
         let expanded = await expand(match)

--- a/controllers/gog.js
+++ b/controllers/gog.js
@@ -381,8 +381,7 @@ const expand = async function(primitiveEntity, GENERATOR=undefined, CREATOR=unde
     }
 
     // Get the Annotations targeting this Entity from the db.  Remove _id property.
-    // Cap the read for parity with the client's historical findByTargetId (limit=100), which
-    // also bounds the query for pathological high-fan-in objects.
+
     let matches = await db.find(queryObj).limit(100).toArray()
     matches = matches.map(o => {
         delete o._id
@@ -390,9 +389,7 @@ const expand = async function(primitiveEntity, GENERATOR=undefined, CREATOR=unde
     })
 
     // Combine the Annotation bodies with the primitive object.
-    // Mirror DEER's client-side expand() (deer-utils.js buildValueObject): every asserted value
-    // becomes a { value, source, evidence } object so the front end reads the server-expanded
-    // object exactly as it read the old client-expanded one (e.g. gloss.text.value.textValue).
+    // Mirror DEER's client-side expand() (deer-utils.js buildValueObject)
     // When more than one current Annotation asserts the same key, collect the values into an Array.
     let expandedEntity = structuredClone(primitiveEntity)
     for(const anno of matches){
@@ -426,10 +423,7 @@ const expand = async function(primitiveEntity, GENERATOR=undefined, CREATOR=unde
 
 /**
  * GET /gog/id/:_id
- * Return the RERUM object for :_id with the descriptive Annotations targeting it already merged in
- * (a server-side expand()).  Because the URL is stable, the response is browser-cacheable, so the
- * front end can fetch a finished object and does NOT need to expand() it client-side (issue #310).
- * Namespaced under /gog rather than overloading the generic GET /v1/id/:_id object route.
+ * Return the RERUM object for :_id with the descriptive Annotations targeting it already merged in.
  * Mirrors the caching/negotiation behavior of the GET /v1/id/:_id handler in controllers/crud.js.
  * */
 const expandedId = async function (req, res, next) {

--- a/controllers/gog.js
+++ b/controllers/gog.js
@@ -423,10 +423,11 @@ const expand = async function(primitiveEntity, GENERATOR=undefined, CREATOR=unde
 }
 
 /**
- * GET /v1/id/:_id/expanded
+ * GET /gog/id/:_id
  * Return the RERUM object for :_id with the descriptive Annotations targeting it already merged in
  * (a server-side expand()).  Because the URL is stable, the response is browser-cacheable, so the
  * front end can fetch a finished object and does NOT need to expand() it client-side (issue #310).
+ * Namespaced under /gog rather than overloading the generic GET /v1/id/:_id object route.
  * Mirrors the caching/negotiation behavior of the GET /v1/id/:_id handler in controllers/crud.js.
  * */
 const expandedId = async function (req, res, next) {

--- a/controllers/gog.js
+++ b/controllers/gog.js
@@ -381,8 +381,8 @@ const expand = async function(primitiveEntity, GENERATOR=undefined, CREATOR=unde
     }
 
     // Get the Annotations targeting this Entity from the db.  Remove _id property.
-
-    let matches = await db.find(queryObj).limit(100).toArray()
+    // Assuming we do not need paged query here
+    let matches = await db.find(queryObj).toArray()
     matches = matches.map(o => {
         delete o._id
         return o

--- a/db-controller.js
+++ b/db-controller.js
@@ -15,7 +15,7 @@ import { putUpdate, patchUpdate, patchSet, patchUnset, overwrite } from './contr
 import { bulkCreate, bulkUpdate } from './controllers/bulk.js'
 import { since, history, idHeadRequest, queryHeadRequest, sinceHeadRequest, historyHeadRequest } from './controllers/history.js'
 import { release } from './controllers/release.js'
-import { _gog_fragments_from_manuscript, _gog_glosses_from_manuscript, expand } from './controllers/gog.js'
+import { _gog_fragments_from_manuscript, _gog_glosses_from_manuscript, expand, expandedId } from './controllers/gog.js'
 
 export default {
     index,
@@ -44,5 +44,6 @@ export default {
     _gog_glosses_from_manuscript,
     _gog_fragments_from_manuscript,
     idNegotiation,
-    expand
+    expand,
+    expandedId
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rerum_server_nodejs",
-  "version": "0.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rerum_server_nodejs",
-      "version": "0.0.0",
+      "version": "1.1.0",
       "license": "UNLICENSED",
       "dependencies": {
         "cookie-parser": "~1.4.7",

--- a/routes/_gog_id.js
+++ b/routes/_gog_id.js
@@ -3,13 +3,13 @@ const router = express.Router()
 //This controller will handle all MongoDB interactions.
 import controller from '../db-controller.js'
 
+// GoG-namespaced, stable, browser-cacheable URL returning the object with its targeting
+// Annotations merged in.  The front end fetches this instead of expanding client-side (issue #310).
 router.route('/:_id')
-    .get(controller.id)
-    .head(controller.idHeadRequest)
+    .get(controller.expandedId)
     .all((req, res, next) => {
         res.statusMessage = 'Improper request method, please use GET.'
         res.status(405).end()
     })
 
 export default router
-

--- a/routes/_gog_id.js
+++ b/routes/_gog_id.js
@@ -1,10 +1,8 @@
 import express from 'express'
 const router = express.Router()
-//This controller will handle all MongoDB interactions.
 import controller from '../db-controller.js'
 
-// GoG-namespaced, stable, browser-cacheable URL returning the object with its targeting
-// Annotations merged in.  The front end fetches this instead of expanding client-side (issue #310).
+// GoG-namespaced, stable, browser-cacheable URL returning the object with its targeting Annotations merged in.
 router.route('/:_id')
     .get(controller.expandedId)
     .all((req, res, next) => {

--- a/routes/id.js
+++ b/routes/id.js
@@ -3,6 +3,15 @@ const router = express.Router()
 //This controller will handle all MongoDB interactions.
 import controller from '../db-controller.js'
 
+// A stable, browser-cacheable URL returning the object with its targeting Annotations merged in.
+// The front end fetches this instead of expanding client-side (issue #310).
+router.route('/:_id/expanded')
+    .get(controller.expandedId)
+    .all((req, res, next) => {
+        res.statusMessage = 'Improper request method, please use GET.'
+        res.status(405).end()
+    })
+
 router.route('/:_id')
     .get(controller.id)
     .head(controller.idHeadRequest)


### PR DESCRIPTION
## Summary

Adds a server-side expansion endpoint so clients can fetch an object with its describing Annotations already merged, instead of expanding on the client. This is the back-end half of the coordinated fix for glossing-entries CenterForDigitalHumanities/glossing-entries#310 ("Too Many Glosses for `localStorage`").

Paired front-end PR: CenterForDigitalHumanities/glossing-entries#319.

## Problem

The Gallery of Glosses list expands every Gloss on the client: fetch the object, query every Annotation targeting it, then merge the Annotation bodies onto it. To avoid paying that 6–10 minute cost on every visit, expanded objects were cached in the browser's `localStorage`, which overflowed the ~5 MB quota and broke the page. The chosen fix (option 2 in the issue) is to expand on the server behind a stable, browser-cacheable URL.

## Changes

- **New route** `GET /gog/id/:_id` (`routes/_gog_id.js`, mounted in `app.js`) → `controller.expandedId`. Namespaced under `/gog` rather than overloading the generic `GET /v1/id/:_id` object route. Only `GET` (and `HEAD`) is supported; other methods return `405`.
- **`expandedId` handler** (`controllers/gog.js`): looks the object up by `_id`/slug (same lookup as `GET /v1/id/:_id`), runs `expand()`, and responds with the same caching/negotiation headers as the id route — `Cache-Control: max-age=86400, must-revalidate`, `Last-Modified`, and `Current-Overwritten-Version` — so the stable URL is cached by the browser for 24h.
- **Fixed and wired up the previously dead `expand()`**: the guard was `if(!primitiveEntity?.["@id"] || primitiveEntity?.id) return` — which bailed out whenever the object carried an `id` — corrected to `if(!primitiveEntity?.["@id"] && !primitiveEntity?.id) return`, so an object keyed by either `@id` or `id` actually expands. Exported `expandedId` through `db-controller.js`.
- **Value-shape parity**: each merged value is wrapped as `{ value, source, evidence }` to match DEER's client-side `buildValueObject`, and repeated keys collect into an Array — so the front end reads the server-expanded object exactly as it read the old client-expanded one (e.g. `gloss.text.value.textValue`). Annotation bodies that don't have exactly one key are skipped rather than aborting the whole expand.

The endpoint accepts any RERUM id. It merges every current Annotation of type `Annotation`/`oa:Annotation` targeting the object (matching both `http`/`https` targets), with no GENERATOR/CREATOR filter, matching the client's historical `expand()` behavior.

## Notes and follow-ups

- Now namespaced under `/gog/id/:_id` (was `/v1/id/:_id/expanded`) so it does not overload the generic object route. This still doesn't stop anyone from using `/gog/id/:_id` to expand their own data — restricting it to GoG data would need an additional guard (e.g. gating on `__rerum.generatedBy` / GENERATOR).
- Requests to `/gog/id/:_id` do not include a Bearer agent, so they can't pull Annotations for just the app making the request (it isn't provided). It pulls from all existing Annotations targeting the entity no matter which app made the Annotations. We could design an optional way for an app agent to be provided.